### PR TITLE
tech: allow tech branch name, warn on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,8 +89,8 @@ const extractTrelloCardIds = (pr, stopOnNonLink = true) => {
   const browserEol = '\r\n';
   // requires that link be alone own line, and allows leading/trailing whitespace
   const linkRegex = /^\s*(https\:\/\/trello\.com\/c\/(\w+)(\/\S*)?)?\s*$/;
-  const branchRegex = /^(fix|feat)_([^_]+)$/;
-  const branchWithSuffixRegex = /^(fix|feat)_([^_]+)_.+$/;
+  const branchRegex = /^(fix|feat|tech)_([^_]+)$/;
+  const branchWithSuffixRegex = /^(fix|feat|tech)_([^_]+)_.+$/;
   
   const cardIds = [];
   const lines = pr.body.split(browserEol);
@@ -183,6 +183,6 @@ const buildTrelloLinkComment = async (cardId) => {
   } catch (error) {
     core.error(util.inspect(error));
     //failure will stop PR from being mergeable if that setting enabled on the repo.  there is not currently a neutral exit in actions v2.
-    core.setFailed(error.message);
+    core.warning(error.message);
   }
 })();


### PR DESCRIPTION
On ne souhaite pas avoir l'action en erreur si le lien trello ne ce fait pas

Résultat attendu:
- All checks have passed (pas de possiblité pour avoir une gihub action en warning pour le moment)
- l'erreur est logger dans l'action dans l'onget checks